### PR TITLE
Add logic for search all regions

### DIFF
--- a/src/spaceone/monitoring/connector/__init__.py
+++ b/src/spaceone/monitoring/connector/__init__.py
@@ -1,1 +1,2 @@
 from spaceone.monitoring.connector.cloudtrail_connector import CloudTrailConnector
+from spaceone.monitoring.connector.ec2_connector import EC2Connector

--- a/src/spaceone/monitoring/connector/ec2_connector.py
+++ b/src/spaceone/monitoring/connector/ec2_connector.py
@@ -1,0 +1,16 @@
+import logging
+from spaceone.core.utils import load_json
+from spaceone.monitoring.libs.connector import AWSConnector
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class EC2Connector(AWSConnector):
+    service = 'ec2'
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+
+    def describe_regions(self):
+        response = self.client.describe_regions()
+        return response.get('Regions', [])

--- a/src/spaceone/monitoring/manager/monitoring_manager.py
+++ b/src/spaceone/monitoring/manager/monitoring_manager.py
@@ -3,6 +3,7 @@ import logging
 from spaceone.core.manager import BaseManager
 from spaceone.monitoring.conf.monitoring_conf import *
 from spaceone.monitoring.connector.cloudtrail_connector import CloudTrailConnector
+from spaceone.monitoring.connector.ec2_connector import EC2Connector
 from spaceone.monitoring.model.log_model import Log, Event
 
 _LOGGER = logging.getLogger(__name__)
@@ -20,6 +21,13 @@ class MonitoringManager(BaseManager):
             event_vos = self.set_events(events, keyword, resource_type)
             yield Log({'results': event_vos})
 
+    def list_regions(self, params):
+        ec2_connector: EC2Connector = self.locator.get_connector('EC2Connector', **params)
+        ec2_connector.set_client('us-east-1')
+
+        regions_info = ec2_connector.describe_regions()
+        return [region_info.get('RegionName') for region_info in regions_info if region_info.get('RegionName')]
+
     def lookup_events(self, params):
         events = []
 
@@ -33,6 +41,8 @@ class MonitoringManager(BaseManager):
             events.extend(_events)
 
         if resource_type == 'AWS::IAM::User':
+            region_names = self.list_regions(params)
+
             console_login_target_user_name = ''
             iam_user_params = copy.deepcopy(params)
             iam_user_params['query']['LookupAttributes'] = \
@@ -42,10 +52,12 @@ class MonitoringManager(BaseManager):
             if _lookup_attr:
                 console_login_target_user_name = _lookup_attr[0].get('AttributeValue', '')
 
-            for iam_user_events in cloudtrail_connector.lookup_events(iam_user_params):
-                for _user_event in iam_user_events:
-                    if _user_event.get('Username') == console_login_target_user_name:
-                        events.append(_user_event)
+            for region_name in region_names:
+                cloudtrail_connector.set_client(region_name)
+                for iam_user_events in cloudtrail_connector.lookup_events(iam_user_params):
+                    for _user_event in iam_user_events:
+                        if _user_event.get('Username') == console_login_target_user_name:
+                            events.append(_user_event)
 
             events = sorted(events, key=lambda event: event.get('EventTime'))
 


### PR DESCRIPTION
### Category
- [ ] New feature
- [ ] Bug fix
- [x] Improvement
- [ ] Refactor
- [ ] etc

### Description
* In case of `lookup_events` API, it is executed separately by region. Therefore, ConsoleLogin event in CloudTrail, it is impossible to predict in which region it will be occurred.
* To get all `ConsoleLogin` event information, Search to all regions.
* Before searching for events of IAM User, add `ec2_client` before doing `lookup_events` and search all target regions through `describe_regions`.
* Executes `lookup_events` on all discovered regions.

### Related issue
* https://github.com/cloudforet-io/plugin-aws-cloudtrail-mon-datasource/issues/3 