### PR TITLE
Update event return chunk

### DIFF
--- a/src/spaceone/monitoring/conf/monitoring_conf.py
+++ b/src/spaceone/monitoring/conf/monitoring_conf.py
@@ -1,6 +1,7 @@
 DEFAULT_REGION = 'us-east-1'
 DEFAULT_SCHEMA = 'aws_access_key'
 NUM_OF_LIMIT = 100
+MAX_EVENT_CHUNK_NUM = 20
 
 EXCLUDE_EVENT_NAME = [
     'AddTags',


### PR DESCRIPTION
### Category
- [ ] New feature
- [x] Bug fix
- [ ] Improvement
- [ ] Refactor
- [ ] etc

### Description
When retrieving CloudTrail event information for Access Key, it returns too much data at once. 
So, add logic to cut it to the appropriate size and return it.

### Related issue
* https://github.com/cloudforet-io/plugin-aws-cloudtrail-mon-datasource/issues/9
