### PR TITLE
Modify role_arn check for assume_role authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 
 Find us also at [Dockerhub](https://hub.docker.com/repository/docker/spaceone/plugin-aws-cloudtrail-mon-datasource)
-> Latest stable version : 1.1.1
+> Latest stable version : 1.1.2
 
 Please contact us if you need any further information. (<support@spaceone.dev>)
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,5 +1,8 @@
 # Plugin AWS CloudTrail Monitoring Data Source Release Notes
 
+## v1.1.2
+* [When setting up a new schema, session setting fails](https://github.com/cloudforet-io/plugin-aws-cloudtrail-mon-datasource/issues/15)
+
 ## v1.1.1
 * [Add to get Access key events through the Cloudtrail](https://github.com/cloudforet-io/plugin-aws-cloudtrail-mon-datasource/issues/9)
 

--- a/src/spaceone/monitoring/libs/connector.py
+++ b/src/spaceone/monitoring/libs/connector.py
@@ -31,9 +31,7 @@ class AWSConnector(BaseConnector):
                                aws_secret_access_key=self.secret_data['aws_secret_access_key'],
                                region_name=region_name)
 
-        # ASSUME ROLE
-        if self.schema == 'aws_assume_role':
-            role_arn = self.secret_data.get('role_arn')
+        if role_arn := self.secret_data.get('role_arn'):
             sts = self.session.client('sts')
 
             _assume_role_request = {


### PR DESCRIPTION
### Category
- [ ] New feature
- [x] Bug fix
- [ ] Improvement
- [ ] Refactor
- [ ] etc

### Description
When creating a `boto3` session, after checking if there is a `role_arn` is existed in secret data, Assume Role is executed, and if there is no `role_arn`, the authentication of the Access Key is executed.

### Known issue
* https://github.com/cloudforet-io/plugin-aws-cloudtrail-mon-datasource/issues/15
